### PR TITLE
V0.148.2

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Hugo"
 description.en = "Static Site Generator"
 description.fr = "Générateur de blog statique"
 
-version = "0.147.9~ynh1"
+version = "0.148.2~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -50,10 +50,10 @@ ram.runtime = "50M"
 
     [resources.sources.main]
     in_subdir = false
-    amd64.url = "https://github.com/gohugoio/hugo/releases/download/v0.147.9/hugo_extended_0.147.9_linux-amd64.tar.gz"
-    amd64.sha256 = "cb077c25518c9263cd506baa2cec7016c41100b1ab4df1c93c110ff1718c98fc"
-    arm64.url = "https://github.com/gohugoio/hugo/releases/download/v0.147.9/hugo_extended_0.147.9_linux-arm64.tar.gz"
-    arm64.sha256 = "e340a4192ef392ef4ef20bf736bf3f17e2b9651e86e31a71f5a48831ebdd2a76"
+    amd64.url = "https://github.com/gohugoio/hugo/releases/download/v0.148.2/hugo_extended_0.148.2_linux-amd64.tar.gz"
+    amd64.sha256 = "dff500ade0d4b999ab0c680f4c6123756bb86904b5924d68c0e8ffb260195277"
+    arm64.url = "https://github.com/gohugoio/hugo/releases/download/v0.148.2/hugo_extended_0.148.2_linux-arm64.tar.gz"
+    arm64.sha256 = "ee9f0cb1e1902137a3d740e046e237e44f8a74afd21332d7ee746640a2deeb29"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.amd64 = ".*amd64.tar.gz"


### PR DESCRIPTION
## Problem

- *The latest release v0.148.2 is out*
https://github.com/gohugoio/hugo/releases/tag/v0.148.2

## Solution

- *Update to v0.148.2*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
